### PR TITLE
Add scripts for project setup and local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,15 @@
-Ionic App Base
-=====================
-
-A starting project for Ionic that optionally supports using custom SCSS.
+# MigHub
 
 ## Using this project
 
-We recommend using the [Ionic CLI](https://github.com/driftyco/ionic-cli) to create new Ionic projects that are based on this project but use a ready-made starter template.
-
-For example, to start a new Ionic project with the default tabs interface, make sure the `ionic` utility is installed:
+Install.
 
 ```bash
-$ npm install -g ionic
+$ script/setup
 ```
 
-Then run: 
+run locally:
 
 ```bash
-$ ionic start myProject tabs
+$ script/server
 ```
-
-More info on this can be found on the Ionic [Getting Started](http://ionicframework.com/getting-started) page and the [Ionic CLI](https://github.com/driftyco/ionic-cli) repo.
-
-## Issues
-Issues have been disabled on this repo, if you do find an issue or have a question consider posting it on the [Ionic Forum](http://forum.ionicframework.com/).  Or else if there is truly an error, follow our guidelines for [submitting an issue](http://ionicframework.com/submit-issue/) to the main Ionic repository.

--- a/script/server
+++ b/script/server
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+ionic serve

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+echo 'Installing dependencies..'
+npm install -g ionic
+npm install -g cordova
+npm install -g gulp-cli
+npm install
+gulp install
+echo 'All dependencies have been setup.'
+echo
+echo 'Run `$ script/server` to serve the app locally.'


### PR DESCRIPTION
This just adds two _very_ simple scripts `setup` and `server`, based on the idea: https://github.com/github/scripts-to-rule-them-all.

The `setup` script should be enough to setup the project for development and `server` to run/serve it locally.
